### PR TITLE
Add Fastlane Android metadata to Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,3 +6,6 @@ files:
     escape_quotes: 0
     escape_special_characters: 0
     type: android
+
+  - source: /fastlane/metadata/android/en-US/**/*.txt
+    translation: /fastlane/metadata/android/%locale%/%relative_path%/%file_name%


### PR DESCRIPTION
I have updated the `crowdin.yml` file to include the Fastlane Android metadata. This will allow the app's store title, descriptions, and changelogs to be translated via Crowdin. I've used the `%locale%` placeholder as recommended by Crowdin and Fastlane documentation to ensure the output matches the expected directory structure for deployment to the Google Play Store.

---
*PR created automatically by Jules for task [14424533165326999955](https://jules.google.com/task/14424533165326999955) started by @jamesarich*