### PR TITLE
Enhance administration UI and feedback on node details screen

### DIFF
--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -428,6 +428,7 @@
     <string name="administration">Administration</string>
     <string name="remote_admin">Remote Administration</string>
     <string name="local_admin">Local Administration</string>
+    <string name="notes_saved">Notes saved</string>
     <string name="bad">Bad</string>
     <string name="fair">Fair</string>
     <string name="good">Good</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -427,6 +427,7 @@
     <string name="env_metrics_log">Environment Metrics</string>
     <string name="administration">Administration</string>
     <string name="remote_admin">Remote Administration</string>
+    <string name="local_admin">Local Administration</string>
     <string name="bad">Bad</string>
     <string name="fair">Fair</string>
     <string name="good">Good</string>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ListItem.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ListItem.kt
@@ -135,6 +135,7 @@ fun BasicListItem(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
+    val alpha = if (enabled) 1f else 0.38f
     ListItem(
         modifier =
         if (onLongClick != null) {
@@ -145,9 +146,11 @@ fun BasicListItem(
             modifier
         },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-        headlineContent = { Text(text = text, color = textColor) },
-        supportingContent = supportingText?.let { { Text(text = it, color = supportingTextColor) } },
-        leadingContent = leadingIcon.icon(leadingIconTint),
+        headlineContent = { Text(text = text, color = textColor.copy(alpha = alpha)) },
+        supportingContent = supportingText?.let {
+            { Text(text = it, color = supportingTextColor.copy(alpha = alpha)) }
+        },
+        leadingContent = leadingIcon.icon(leadingIconTint.copy(alpha = alpha)),
         trailingContent = trailingContent,
     )
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/AdministrationSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/AdministrationSection.kt
@@ -40,6 +40,7 @@ import org.meshtastic.core.strings.firmware_edition
 import org.meshtastic.core.strings.installed_firmware_version
 import org.meshtastic.core.strings.latest_alpha_firmware
 import org.meshtastic.core.strings.latest_stable_firmware
+import org.meshtastic.core.strings.local_admin
 import org.meshtastic.core.strings.remote_admin
 import org.meshtastic.core.strings.request_metadata
 import org.meshtastic.core.ui.component.ListItem
@@ -66,14 +67,17 @@ fun AdministrationSection(
                 leadingIcon = Icons.Rounded.Memory,
                 trailingIcon = null,
                 onClick = {
-                    onAction(NodeDetailAction.TriggerServiceAction(ServiceAction.GetDeviceMetadata(node.num)))
+                    onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.RequestMetadata(node)))
                 },
             )
 
             SectionDivider()
 
             ListItem(
-                text = stringResource(Res.string.remote_admin),
+                text =
+                stringResource(
+                    if (metricsState.isLocal) Res.string.local_admin else Res.string.remote_admin,
+                ),
                 leadingIcon = Icons.Rounded.Settings,
                 enabled = metricsState.isLocal || node.metadata != null,
             ) {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeMenu.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeMenu.kt
@@ -121,6 +121,8 @@ sealed class NodeMenuAction {
 
     data class RequestNeighborInfo(val node: Node) : NodeMenuAction()
 
+    data class RequestMetadata(val node: Node) : NodeMenuAction()
+
     data class RequestPosition(val node: Node) : NodeMenuAction()
 
     data class RequestTelemetry(val node: Node, val type: TelemetryType) : NodeMenuAction()

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
@@ -293,6 +293,12 @@ constructor(
                     action.node.num,
                     action.node.user.long_name ?: "",
                 )
+            is NodeMenuAction.RequestMetadata ->
+                nodeRequestActions.requestMetadata(
+                    viewModelScope,
+                    action.node.num,
+                    action.node.user.long_name ?: "",
+                )
             is NodeMenuAction.RequestPosition ->
                 nodeRequestActions.requestPosition(viewModelScope, action.node.num, action.node.user.long_name ?: "")
             is NodeMenuAction.RequestTelemetry ->

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.meshtastic.core.data.repository.DeviceHardwareRepository
@@ -271,7 +273,8 @@ constructor(
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), NodeDetailUiState())
 
-    val effects: SharedFlow<NodeRequestEffect> = nodeRequestActions.effects
+    val effects: SharedFlow<NodeRequestEffect> = merge(nodeRequestActions.effects, nodeManagementActions.effects)
+        .shareIn(viewModelScope, SharingStarted.WhileSubscribed(5000))
 
     fun start(nodeId: Int) {
         if (manualNodeId.value != nodeId) {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeRequestActions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeRequestActions.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
+import org.meshtastic.core.service.ServiceAction
 import org.meshtastic.core.service.ServiceRepository
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.neighbor_info
@@ -38,6 +39,7 @@ import org.meshtastic.core.strings.request_air_quality_metrics
 import org.meshtastic.core.strings.request_device_metrics
 import org.meshtastic.core.strings.request_environment_metrics
 import org.meshtastic.core.strings.request_host_metrics
+import org.meshtastic.core.strings.request_metadata
 import org.meshtastic.core.strings.request_pax_metrics
 import org.meshtastic.core.strings.request_power_metrics
 import org.meshtastic.core.strings.requesting_from
@@ -62,6 +64,23 @@ class NodeRequestActions @Inject constructor(private val serviceRepository: Serv
 
     private val _lastRequestNeighborTimes = MutableStateFlow<Map<Int, Long>>(emptyMap())
     val lastRequestNeighborTimes: StateFlow<Map<Int, Long>> = _lastRequestNeighborTimes.asStateFlow()
+
+    fun requestMetadata(scope: CoroutineScope, destNum: Int, longName: String) {
+        scope.launch(Dispatchers.IO) {
+            Logger.i { "Requesting Metadata for '$destNum'" }
+            try {
+                serviceRepository.onServiceAction(ServiceAction.GetDeviceMetadata(destNum))
+                _effects.emit(
+                    NodeRequestEffect.ShowFeedback(
+                        Res.string.requesting_from,
+                        listOf(Res.string.request_metadata, longName),
+                    ),
+                )
+            } catch (ex: Exception) {
+                Logger.e { "Request metadata error: ${ex.message}" }
+            }
+        }
+    }
 
     fun requestUserInfo(scope: CoroutineScope, destNum: Int, longName: String) {
         scope.launch(Dispatchers.IO) {


### PR DESCRIPTION
This change improves the administration section on the node details screen. It now distinguishes between local and remote administration by updating the button label. The button is correctly disabled when remote node metadata is not available, and a visual disabled state is implemented for all ListItems by applying a 0.38f alpha. Additionally, requesting metadata now triggers a snackbar notification for better user feedback.

---
*PR created automatically by Jules for task [17047650175107419251](https://jules.google.com/task/17047650175107419251) started by @jamesarich*