### PR TITLE
Replace ZXing with ML Kit Scanner

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,7 +229,6 @@ dependencies {
     implementation(libs.androidx.paging.compose)
     implementation(libs.coil.network.okhttp)
     implementation(libs.coil.svg)
-    implementation(libs.zxing.android.embedded) { isTransitive = false }
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.org.eclipse.paho.client.mqttv3)
@@ -246,8 +245,10 @@ dependencies {
 
     googleImplementation(libs.location.services)
     googleImplementation(libs.play.services.maps)
+    googleImplementation(libs.play.services.mlkit.barcode.scanning)
 
     fdroidImplementation(libs.osmdroid.android)
+    fdroidImplementation(libs.mlkit.barcode.scanning)
     fdroidImplementation(libs.osmdroid.geopackage) { exclude(group = "com.j256.ormlite") }
 
     androidTestImplementation(libs.androidx.test.runner)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
     <!-- Needed to open our bluetooth connection to our paired device (after reboot) -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-    <!-- zxing library for QR Code scanning using camera -->
+    <!-- Camera permission for QR Code scanning -->
     <uses-permission android:name="android.permission.CAMERA" />
 
     <uses-feature
@@ -94,7 +94,7 @@
         </intent>
     </queries>
 
-    <!-- hardware acceleration is required for zxing barcode lib -->
+    <!-- hardware acceleration is required for barcode scanning -->
     <application
         android:name="com.geeksville.mesh.MeshUtilApplication"
         android:allowBackup="false"
@@ -139,11 +139,6 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
-
-        <activity
-            android:name="com.journeyapps.barcodescanner.CaptureActivity"
-            android:screenOrientation="unspecified"
-            tools:replace="screenOrientation" />
 
         <activity
             android:name="com.geeksville.mesh.MainActivity"

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -90,8 +90,7 @@ import co.touchlab.kermit.Logger
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
-import com.journeyapps.barcodescanner.ScanContract
-import com.journeyapps.barcodescanner.ScanOptions
+import org.meshtastic.core.ui.qr.MlKitScanContract
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.Channel
@@ -200,22 +199,17 @@ fun ChannelScreen(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val barcodeLauncher =
-        rememberLauncherForActivityResult(ScanContract()) { result ->
-            if (result.contents != null) {
-                viewModel.requestChannelUrl(result.contents.toUri()) {
+        rememberLauncherForActivityResult(MlKitScanContract()) { contents ->
+            if (contents != null) {
+                viewModel.requestChannelUrl(contents.toUri()) {
                     scope.launch { context.showToast(Res.string.channel_invalid) }
                 }
             }
         }
 
-    fun zxingScan() {
-        Logger.d { "Starting zxing QR code scanner" }
-        val zxingScan = ScanOptions()
-        zxingScan.setCameraId(0)
-        zxingScan.setPrompt("")
-        zxingScan.setBeepEnabled(false)
-        zxingScan.setDesiredBarcodeFormats(ScanOptions.QR_CODE)
-        barcodeLauncher.launch(zxingScan)
+    fun mlKitScan() {
+        Logger.d { "Starting ML Kit QR code scanner" }
+        barcodeLauncher.launch(Unit)
     }
 
     val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
@@ -368,7 +362,7 @@ fun ChannelScreen(
                     onPositiveClicked = {
                         focusManager.clearFocus()
                         if (cameraPermissionState.status.isGranted) {
-                            zxingScan()
+                            mlKitScan()
                         } else {
                             cameraPermissionState.launchPermissionRequest()
                         }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     api(libs.androidx.annotation)
     api(libs.kotlinx.serialization.json)
     implementation(libs.kermit)
-    implementation(libs.zxing.android.embedded) { isTransitive = false }
     implementation(libs.zxing.core)
 
     testImplementation(libs.androidx.core.ktx)

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -17,12 +17,13 @@
 package org.meshtastic.core.model.util
 
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.net.Uri
 import android.util.Base64
 import co.touchlab.kermit.Logger
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
-import com.journeyapps.barcodescanner.BarcodeEncoder
+import com.google.zxing.common.BitMatrix
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.model.Channel
 import org.meshtastic.proto.ChannelSet
@@ -93,9 +94,21 @@ fun ChannelSet.qrCode(shouldAdd: Boolean): Bitmap? = try {
     val multiFormatWriter = MultiFormatWriter()
     val bitMatrix =
         multiFormatWriter.encode(getChannelUrl(false, shouldAdd).toString(), BarcodeFormat.QR_CODE, 960, 960)
-    val barcodeEncoder = BarcodeEncoder()
-    barcodeEncoder.createBitmap(bitMatrix)
+    bitMatrix.toBitmap()
 } catch (ex: Throwable) {
     Logger.e { "URL was too complex to render as barcode" }
     null
+}
+
+fun BitMatrix.toBitmap(): Bitmap {
+    val pixels = IntArray(width * height)
+    for (y in 0 until height) {
+        val offset = y * width
+        for (x in 0 until width) {
+            pixels[offset + x] = if (get(x, y)) Color.BLACK else Color.WHITE
+        }
+    }
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+    return bitmap
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -57,9 +57,12 @@ dependencies {
     implementation(libs.androidx.compose.ui.text)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.emoji2.emojipicker)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.view)
+    compileOnly(libs.mlkit.barcode.scanning)
     implementation(libs.guava)
     implementation(libs.zxing.core)
-    implementation(libs.zxing.android.embedded)
     implementation(libs.kermit)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/core/ui/src/main/AndroidManifest.xml
+++ b/core/ui/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <application>
+        <activity
+            android:name="org.meshtastic.core.ui.qr.MlKitScanningActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.NoActionBar" />
+    </application>
+
+</manifest>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/MlKitScanContract.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/MlKitScanContract.kt
@@ -1,0 +1,24 @@
+package org.meshtastic.core.ui.qr
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+
+class MlKitScanContract : ActivityResultContract<Unit, String?>() {
+    override fun createIntent(context: Context, input: Unit): Intent {
+        return Intent(context, MlKitScanningActivity::class.java)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): String? {
+        return if (resultCode == Activity.RESULT_OK) {
+            intent?.getStringExtra(EXTRA_SCAN_RESULT)
+        } else {
+            null
+        }
+    }
+
+    companion object {
+        const val EXTRA_SCAN_RESULT = "scan_result"
+    }
+}

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/MlKitScanningActivity.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/MlKitScanningActivity.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025-2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.qr
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import org.meshtastic.core.ui.theme.AppTheme
+import java.util.concurrent.Executors
+
+class MlKitScanningActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                ScannerScreen(onResult = { result ->
+                    val data = Intent().apply {
+                        putExtra(MlKitScanContract.EXTRA_SCAN_RESULT, result)
+                    }
+                    setResult(RESULT_OK, data)
+                    finish()
+                })
+            }
+        }
+    }
+}
+
+@Composable
+fun ScannerScreen(onResult: (String) -> Unit) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val cameraExecutor = remember { Executors.newSingleThreadExecutor() }
+    val barcodeScanner = remember {
+        val options = BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .build()
+        BarcodeScanning.getClient(options)
+    }
+    var isScanning by remember { mutableStateOf(true) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            cameraExecutor.shutdown()
+            barcodeScanner.close()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                val previewView = PreviewView(ctx)
+                val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
+
+                cameraProviderFuture.addListener({
+                    val cameraProvider = cameraProviderFuture.get()
+                    val preview = Preview.Builder().build().also {
+                        it.setSurfaceProvider(previewView.surfaceProvider)
+                    }
+
+                    val imageAnalysis = ImageAnalysis.Builder()
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .build()
+
+                    imageAnalysis.setAnalyzer(cameraExecutor) { imageProxy ->
+                        if (isScanning) {
+                            processImageProxy(barcodeScanner, imageProxy) { result ->
+                                if (isScanning) {
+                                    isScanning = false
+                                    onResult(result)
+                                }
+                            }
+                        } else {
+                            imageProxy.close()
+                        }
+                    }
+
+                    val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+                    try {
+                        cameraProvider.unbindAll()
+                        cameraProvider.bindToLifecycle(
+                            lifecycleOwner,
+                            cameraSelector,
+                            preview,
+                            imageAnalysis
+                        )
+                    } catch (e: Exception) {
+                        // Handle errors
+                    }
+                }, ContextCompat.getMainExecutor(ctx))
+                previewView
+            }
+        )
+    }
+}
+
+@SuppressLint("UnsafeOptInUsageError")
+private fun processImageProxy(
+    barcodeScanner: BarcodeScanner,
+    imageProxy: ImageProxy,
+    onResult: (String) -> Unit
+) {
+    val mediaImage = imageProxy.image
+    if (mediaImage != null) {
+        val image = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+        barcodeScanner.process(image)
+            .addOnSuccessListener { barcodes ->
+                for (barcode in barcodes) {
+                    barcode.rawValue?.let {
+                        onResult(it)
+                    }
+                }
+            }
+            .addOnFailureListener {
+                // Handle failure
+            }
+            .addOnCompleteListener {
+                imageProxy.close()
+            }
+    } else {
+        imageProxy.close()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,11 @@ compose-multiplatform = "1.10.0"
 # Google
 hilt = "2.59.1"
 maps-compose = "8.0.1"
+mlkit-barcode-scanning = "17.3.0"
+play-services-mlkit-barcode-scanning = "18.3.1"
+
+# AndroidX
+camerax = "1.4.1"
 
 # Networking
 ktor = "3.4.0"
@@ -54,6 +59,9 @@ dependency-guard = "0.5.0"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.12.3" }
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
+androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "camerax" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.17.0" }
 androidx-core-location-altitude = { module = "androidx.core:core-location-altitude", version = "1.0.0-beta01" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.2.0" }
@@ -111,6 +119,8 @@ hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", vers
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt" }
 location-services = { module = "com.google.android.gms:play-services-location", version = "21.3.0" }
+mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "mlkit-barcode-scanning" }
+play-services-mlkit-barcode-scanning = { module = "com.google.android.gms:play-services-mlkit-barcode-scanning", version.ref = "play-services-mlkit-barcode-scanning" }
 maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "maps-compose" }
 maps-compose-utils = { module = "com.google.maps.android:maps-compose-utils", version.ref = "maps-compose" }
 maps-compose-widgets = { module = "com.google.maps.android:maps-compose-widgets", version.ref = "maps-compose" }
@@ -177,7 +187,6 @@ osmdroid-geopackage = { module = "org.osmdroid:osmdroid-geopackage", version.ref
 kermit = { module = "co.touchlab:kermit", version = "2.0.8" }
 
 usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version = "3.10.0" }
-zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version = "4.3.0" }
 vico-compose = { group = "com.patrykandpatrick.vico", name = "compose", version.ref = "vico" }
 vico-compose-m2 = { group = "com.patrykandpatrick.vico", name = "compose-m2", version.ref = "vico" }
 vico-compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", version.ref = "vico" }


### PR DESCRIPTION
This change replaces the `zxing` barcode scanning library with Google's ML Kit scanner. To optimize build size, we use the bundled version for the F-Droid flavor and the unbundled Play Services version for the Google flavor. The heavy `zxing-android-embedded` dependency has been removed, while `zxing-core` is kept for QR code generation using a new local extension. A unified `MlKitScanningActivity` and `MlKitScanContract` in `core:ui` handle the scanning logic using CameraX.

---
*PR created automatically by Jules for task [9245170933500061778](https://jules.google.com/task/9245170933500061778) started by @jamesarich*