### PR TITLE
AGP 9 Migration Fixes and Build Logic Cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,7 +187,10 @@ androidComponents {
     }
 }
 
-project.afterEvaluate { logger.lifecycle("Version code is set to: ${android.defaultConfig.versionCode}") }
+project.afterEvaluate {
+    val applicationExtension = extensions.getByType<ApplicationExtension>()
+    logger.lifecycle("Version code is set to: ${applicationExtension.defaultConfig.versionCode}")
+}
 
 dependencies {
     implementation(projects.core.analytics)

--- a/build-logic/convention/src/main/kotlin/KmpLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpLibraryComposeConventionPlugin.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.meshtastic.buildlogic.configureComposeCompiler
 import org.meshtastic.buildlogic.libs
 import org.meshtastic.buildlogic.plugin
+import org.meshtastic.buildlogic.version
 
 class KmpLibraryComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -31,12 +32,11 @@ class KmpLibraryComposeConventionPlugin : Plugin<Project> {
             apply(plugin = libs.plugin("compose-compiler").get().pluginId)
             apply(plugin = libs.plugin("compose-multiplatform").get().pluginId)
 
-            val compose = extensions.getByType(ComposeExtension::class.java)
             extensions.configure<KotlinMultiplatformExtension> {
                 sourceSets.getByName("commonMain").dependencies {
-                    implementation(compose.dependencies.runtime)
+                    implementation(libs.findLibrary("compose-runtime").get())
                     // API because consuming modules will usually need the resource types
-                    api(compose.dependencies.components.resources)
+                    api(libs.findLibrary("compose-components-resources").get())
                 }
             }
             configureComposeCompiler()

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -23,6 +23,5 @@ kotlin {
 
     sourceSets {
         androidMain.dependencies { implementation(libs.androidx.core.ktx) }
-        commonTest.dependencies { implementation(kotlin("test")) }
     }
 }

--- a/core/strings/build.gradle.kts
+++ b/core/strings/build.gradle.kts
@@ -23,8 +23,6 @@ plugins {
 kotlin {
     @Suppress("UnstableApiUsage")
     android { androidResources.enable = true }
-
-    sourceSets { commonTest.dependencies { implementation(kotlin("test")) } }
 }
 
 compose.resources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -188,6 +188,8 @@ android-tools-common = { module = "com.android.tools:common", version = "32.0.0"
 androidx-room-gradlePlugin = { module = "androidx.room:room-gradle-plugin", version.ref = "room" }
 compose-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 compose-multiplatform-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
 datadog-gradlePlugin = { module = "com.datadoghq.dd-sdk-android-gradle-plugin:com.datadoghq.dd-sdk-android-gradle-plugin.gradle.plugin", version = "1.22.0" }
 detekt-compose = { module = "io.nlopez.compose.rules:detekt", version = "0.5.6" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }


### PR DESCRIPTION
This change addresses several deprecation warnings and build logic issues encountered when preparing for AGP 9. It specifically fixes direct Project.android access, updates Compose Multiplatform dependency handling in convention plugins to use the version catalog, and cleans up unused Kotlin source sets. It also ensures the project remains on Java 17 for compatibility with published core libraries.

---
*PR created automatically by Jules for task [5015320572489201444](https://jules.google.com/task/5015320572489201444) started by @jamesarich*