### PR TITLE
Enhance Node Administration UI and Feedback

### DIFF
--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -427,6 +427,7 @@
     <string name="env_metrics_log">Environment Metrics</string>
     <string name="administration">Administration</string>
     <string name="remote_admin">Remote Administration</string>
+    <string name="local_admin">Local Administration</string>
     <string name="bad">Bad</string>
     <string name="fair">Fair</string>
     <string name="good">Good</string>
@@ -792,6 +793,7 @@
     <string name="request">Request</string>
     <string name="requesting_from">Requesting %1$s from %2$s</string>
     <string name="user_info">User info</string>
+    <string name="device_metadata">device metadata</string>
     <string name="request_neighbor_info">NeighborInfo (2.7.15+)</string>
     <string name="request_telemetry">Request Telemetry</string>
     <string name="request_device_metrics">Device Metrics</string>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ListItem.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ListItem.kt
@@ -135,6 +135,7 @@ fun BasicListItem(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
+    val alpha = if (enabled) 1f else 0.38f
     ListItem(
         modifier =
         if (onLongClick != null) {
@@ -145,9 +146,10 @@ fun BasicListItem(
             modifier
         },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-        headlineContent = { Text(text = text, color = textColor) },
-        supportingContent = supportingText?.let { { Text(text = it, color = supportingTextColor) } },
-        leadingContent = leadingIcon.icon(leadingIconTint),
+        headlineContent = { Text(text = text, color = textColor.copy(alpha = alpha)) },
+        supportingContent =
+        supportingText?.let { { Text(text = it, color = supportingTextColor.copy(alpha = alpha)) } },
+        leadingContent = leadingIcon.icon(leadingIconTint.copy(alpha = alpha)),
         trailingContent = trailingContent,
     )
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/AdministrationSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/AdministrationSection.kt
@@ -32,7 +32,6 @@ import org.meshtastic.core.database.entity.asDeviceVersion
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.DeviceVersion
 import org.meshtastic.core.navigation.SettingsRoutes
-import org.meshtastic.core.service.ServiceAction
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.administration
 import org.meshtastic.core.strings.firmware
@@ -40,6 +39,7 @@ import org.meshtastic.core.strings.firmware_edition
 import org.meshtastic.core.strings.installed_firmware_version
 import org.meshtastic.core.strings.latest_alpha_firmware
 import org.meshtastic.core.strings.latest_stable_firmware
+import org.meshtastic.core.strings.local_admin
 import org.meshtastic.core.strings.remote_admin
 import org.meshtastic.core.strings.request_metadata
 import org.meshtastic.core.ui.component.ListItem
@@ -65,15 +65,13 @@ fun AdministrationSection(
                 text = stringResource(Res.string.request_metadata),
                 leadingIcon = Icons.Rounded.Memory,
                 trailingIcon = null,
-                onClick = {
-                    onAction(NodeDetailAction.TriggerServiceAction(ServiceAction.GetDeviceMetadata(node.num)))
-                },
+                onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.RequestMetadata(node))) },
             )
 
             SectionDivider()
 
             ListItem(
-                text = stringResource(Res.string.remote_admin),
+                text = stringResource(if (metricsState.isLocal) Res.string.local_admin else Res.string.remote_admin),
                 leadingIcon = Icons.Rounded.Settings,
                 enabled = metricsState.isLocal || node.metadata != null,
             ) {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeMenu.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeMenu.kt
@@ -123,6 +123,8 @@ sealed class NodeMenuAction {
 
     data class RequestPosition(val node: Node) : NodeMenuAction()
 
+    data class RequestMetadata(val node: Node) : NodeMenuAction()
+
     data class RequestTelemetry(val node: Node, val type: TelemetryType) : NodeMenuAction()
 
     data class TraceRoute(val node: Node) : NodeMenuAction()

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
@@ -304,6 +304,8 @@ constructor(
                 )
             is NodeMenuAction.TraceRoute ->
                 nodeRequestActions.requestTraceroute(viewModelScope, action.node.num, action.node.user.long_name ?: "")
+            is NodeMenuAction.RequestMetadata ->
+                nodeRequestActions.requestMetadata(viewModelScope, action.node.num, action.node.user.long_name ?: "")
             else -> {}
         }
     }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeRequestActions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeRequestActions.kt
@@ -30,8 +30,10 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
+import org.meshtastic.core.service.ServiceAction
 import org.meshtastic.core.service.ServiceRepository
 import org.meshtastic.core.strings.Res
+import org.meshtastic.core.strings.device_metadata
 import org.meshtastic.core.strings.neighbor_info
 import org.meshtastic.core.strings.position
 import org.meshtastic.core.strings.request_air_quality_metrics
@@ -152,6 +154,23 @@ class NodeRequestActions @Inject constructor(private val serviceRepository: Serv
                 )
             } catch (ex: android.os.RemoteException) {
                 Logger.e { "Request traceroute error: ${ex.message}" }
+            }
+        }
+    }
+
+    fun requestMetadata(scope: CoroutineScope, destNum: Int, longName: String) {
+        scope.launch(Dispatchers.IO) {
+            Logger.i { "Requesting device metadata for '$destNum'" }
+            try {
+                serviceRepository.onServiceAction(ServiceAction.GetDeviceMetadata(destNum))
+                _effects.emit(
+                    NodeRequestEffect.ShowFeedback(
+                        Res.string.requesting_from,
+                        listOf(Res.string.device_metadata, longName),
+                    ),
+                )
+            } catch (ex: Exception) {
+                Logger.e { "Request metadata error: ${ex.message}" }
             }
         }
     }


### PR DESCRIPTION
This change improves the user experience on the Node Details screen by providing better visual cues and feedback for administration actions.

Key improvements:
1.  **Visual Disabled State**: Updated `BasicListItem` to apply a `0.38f` alpha to text and icons when `enabled` is false. This ensures that disabled items (like the Remote Administration button when metadata is missing) actually look disabled.
2.  **Contextual Administration Labels**: The administration button now correctly switches between "Local Administration" and "Remote Administration" depending on whether the node is the local one or a remote one.
3.  **Request Metadata Feedback**: Clicking the "Metadata" request button now triggers a snackbar notification (e.g., "Requesting device metadata from [Node Name]"), consistent with other request actions in the app.
4.  **Architectural Alignment**: Moved the metadata request logic into `NodeRequestActions` and `NodeDetailViewModel` to leverage the existing snackbar effect system.

---
*PR created automatically by Jules for task [5738172749880696021](https://jules.google.com/task/5738172749880696021) started by @jamesarich*